### PR TITLE
Use node v10 as oldest possible version

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "stdout-stderr": "^0.1.13"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "files": [
     "/oclif.manifest.json",


### PR DESCRIPTION
Because of used syntax, the code won't work with nodejs 8.
Hence, changing the oldest possible version to be node 10.